### PR TITLE
Better react mermaid

### DIFF
--- a/components/mermaid.tsx
+++ b/components/mermaid.tsx
@@ -1,58 +1,31 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import mermaid from "mermaid";
 import { useEffect, useState } from "react";
 
 mermaid.initialize({
   startOnLoad: true,
-  theme: "default",
   securityLevel: "loose",
+  sequence: { mirrorActors: false },
+  theme: "base",
+  themeVariables: {
+    background: "#fff",
+    mainBkg: "#fff",
+    primaryColor: "#fff",
+    textColor: "#171717",
+    lineColor: "#171717",
+    actorBorder: "#171717",
+  },
   themeCSS: `
-    g.classGroup rect {
-      fill: #282a36;
-      stroke: #6272a4;
-    } 
-    g.classGroup text {
-      fill: #f8f8f2;
+    .actor {
+      stroke-width: 2px;
     }
-    g.classGroup line {
-      stroke: #f8f8f2;
-      stroke-width: 0.5;
+
+    .messageText a {
+      text-decoration: underline;
     }
-    .classLabel .box {
-      stroke: #21222c;
-      stroke-width: 3;
-      fill: #21222c;
-      opacity: 1;
-    }
-    .classLabel .label {
-      fill: #f1fa8c;
-    }
-    .relation {
-      stroke: #ff79c6;
-      stroke-width: 1;
-    }
-    #compositionStart, #compositionEnd {
-      fill: #bd93f9;
-      stroke: #bd93f9;
-      stroke-width: 1;
-    }
-    #aggregationEnd, #aggregationStart {
-      fill: #21222c;
-      stroke: #50fa7b;
-      stroke-width: 1;
-    }
-    #dependencyStart, #dependencyEnd {
-      fill: #00bcd4;
-      stroke: #00bcd4;
-      stroke-width: 1;
-    } 
-    #extensionStart, #extensionEnd {
-      fill: #f8f8f2;
-      stroke: #f8f8f2;
-      stroke-width: 1;
-    }`,
-  fontFamily: "Fira Code",
+  `,
 });
 
 const replacer = (tag: string) =>

--- a/tests/e2e/happy-paths.test.ts
+++ b/tests/e2e/happy-paths.test.ts
@@ -28,11 +28,11 @@ test("navigates to a correctly rendered tx detail", async ({ page }) => {
   //TODO: use non-image snapshot testing (for svg)
   await expect(
     page.getByText("slay3r1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmvk3r3j"),
-  ).toHaveCount(2);
+  ).toHaveCount(1);
 
   await expect(
     page.getByText("slay3r1fqg7raeca9peg0zkfp629m92qnjrpyggd2cfgj"),
-  ).toHaveCount(2);
+  ).toHaveCount(1);
 
   await expect(page.getByText("Send")).toBeVisible();
 });


### PR DESCRIPTION
Replacing the inner html link from a sequence diagram depended on a `setTimeout` which caused a flash of badly rendered diagram. This makes the rendering more robust and also tweaks the styles to fit the default from the component library.

<img width="1164" alt="better-react-mermaid" src="https://github.com/user-attachments/assets/c42c7587-eb6b-48a9-8e8d-8b6561f099e3">
