### PR TITLE
Show actor type

### DIFF
--- a/lib/chain.ts
+++ b/lib/chain.ts
@@ -1,8 +1,10 @@
 //TODO - query from chain
-export function getAddressType(_address: string) {
-  if (Math.random() < 0.5) {
-    return "account";
+export function getAddressType(address: string) {
+  const unprefixedAddress = address.slice(7);
+
+  if (unprefixedAddress.includes("i") || unprefixedAddress.includes("u")) {
+    return "validator";
   }
 
-  return Math.random() < 0.5 ? "contract" : "validator";
+  return unprefixedAddress.includes("a") ? "account" : "contract";
 }

--- a/lib/chain.ts
+++ b/lib/chain.ts
@@ -1,0 +1,8 @@
+//TODO - query from chain
+export function getAddressType(_address: string) {
+  if (Math.random() < 0.5) {
+    return "account";
+  }
+
+  return Math.random() < 0.5 ? "contract" : "validator";
+}

--- a/lib/mermaid.ts
+++ b/lib/mermaid.ts
@@ -1,3 +1,5 @@
+import { getAddressType } from "./chain";
+
 type TreeNode = {
   id: string;
   parentId: string | null;
@@ -88,8 +90,27 @@ export function sequenceDiagramFromSpans(spans: any) {
 
     console.log({ tx, sender, recipient });
 
+    chart += `\n${getActorBox(sender)}`;
+    chart += `\n${getActorBox(recipient)}`;
+
     chart += `\n${sender}->>+${recipient}: <a href="/txs/${msgSendSpan._source.traceID}/${msgSendSpan._source.spanID}">🏦 Send</a>`;
   }
 
   return chart;
 }
+
+const getActorBox = (address: string) => {
+  switch (getAddressType(address)) {
+    case "account": {
+      return `actor ${address}`;
+    }
+    case "contract": {
+      return `participant ${address} as 📜 ${address}`;
+    }
+    case "validator": {
+      return `participant ${address} as 📋 ${address}`;
+    }
+    default:
+      return "";
+  }
+};


### PR DESCRIPTION
Closes #2.

Adds a mock function that randomly tells you if an address is an account, a contract, or a validator. The diagram renders differently depending on that type of address.

An account sends to a contract:
<img width="1172" alt="show-actor-type-1" src="https://github.com/user-attachments/assets/25e16b37-b48b-4d1d-9dbc-97c25e8edbc5">

A validator sends to an account:
<img width="1148" alt="show-actor-type-2" src="https://github.com/user-attachments/assets/1703d22b-6f33-4478-bd79-d7af66563e33">
