### PR TITLE
Add types to queries

### DIFF
--- a/app/txs/[...span]/page.tsx
+++ b/app/txs/[...span]/page.tsx
@@ -1,6 +1,6 @@
 import TxData from "@/components/tx-data";
 
-export default function Tx({ params }: { params: { span: any[] } }) {
+export default function Tx({ params }: { params: { span: string[] } }) {
   const [txId, spanId] = params.span;
 
   return (

--- a/components/tx-data.tsx
+++ b/components/tx-data.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { sequenceDiagramFromSpans } from "@/lib/mermaid";
+import { Tx, TxSchema } from "@/types/txs";
 import { useQuery } from "@tanstack/react-query";
+import { z } from "zod";
 import Mermaid from "./mermaid";
 
 type TxDataProps = {
@@ -10,11 +12,7 @@ type TxDataProps = {
 };
 
 export default function TxData({ txId, spanId }: TxDataProps) {
-  const {
-    isPending,
-    error,
-    data: spans,
-  } = useQuery({
+  const { isPending, error, data } = useQuery({
     queryKey: [`tx-${txId}`],
     queryFn: () =>
       fetch(`http://localhost:4000/api/v1/txs?traceID=${txId}`)
@@ -26,14 +24,24 @@ export default function TxData({ txId, spanId }: TxDataProps) {
 
   if (error) return "An error has occurred: " + error.message;
 
+  const spans: Readonly<Array<Tx>> = z.array(TxSchema).parse(data);
+
   const mermaidChart = sequenceDiagramFromSpans(spans);
 
-  const span = spans.find((span: any) => span._source.spanID === spanId);
+  const span = spans.find((span: Tx) => span.spanId === spanId);
 
   return (
     <div>
       <Mermaid chart={mermaidChart} />
-      {span ? <pre>{JSON.stringify(span._source.tags, null, 2)}</pre> : null}
+      {span ? (
+        <pre>
+          {JSON.stringify(
+            Object.fromEntries(Array.from(span.tags).sort()),
+            null,
+            2,
+          )}
+        </pre>
+      ) : null}
     </div>
   );
 }

--- a/types/txs.ts
+++ b/types/txs.ts
@@ -1,10 +1,36 @@
-export type Tx = {
-  _id: string;
-  _source: {
-    traceID: string;
-    spanID: string;
-    operationName: string;
-    references: Array<{ refType: string; traceID: string; spanID: string }>;
-    tags: Array<{ key: string; type: string; value: string }>;
-  };
-};
+import { z } from "zod";
+
+export const TxSchema = z
+  .object({
+    _id: z.string(),
+    _source: z.object({
+      traceID: z.string(),
+      spanID: z.string(),
+      operationName: z.string(),
+      references: z.array(
+        z.object({
+          refType: z.string(),
+          traceID: z.string(),
+          spanID: z.string(),
+        }),
+      ),
+      tags: z.array(
+        z.object({ key: z.string(), type: z.string(), value: z.string() }),
+      ),
+    }),
+  })
+  .transform((v) => ({
+    //NOTE - Using _id for React keyprop for now since I found different spans with same spanId
+    _id: v._id,
+    traceId: v._source.traceID,
+    spanId: v._source.spanID,
+    operationName: v._source.operationName,
+    parentSpanId:
+      v._source.references.find(
+        (ref) =>
+          ref.traceID === v._source.traceID && ref.refType === "CHILD_OF",
+      )?.spanID ?? null,
+    tags: new Map(v._source.tags.map(({ key, value }) => [key, value])),
+  }));
+
+export type Tx = Readonly<z.infer<typeof TxSchema>>;


### PR DESCRIPTION
Closes #5.

The wip rendering of the tags also shows now as a map, since we use that type for that field now:
<img width="1169" alt="type-traces" src="https://github.com/user-attachments/assets/079e1f21-6724-4d80-9e25-717ef4329427">
