### PR TITLE
Avoid reloading Tx view

### DIFF
--- a/app/@span/(.)[...span]/page.tsx
+++ b/app/@span/(.)[...span]/page.tsx
@@ -1,8 +1,15 @@
 import TxData from "@/components/tx-data";
-import { Sheet, SheetContent } from "@/components/ui/sheet";
+const traceIdLength = 32;
 
-export default function Tx({ params }: { params: { span: string[] } }) {
-  const [txId, spanId] = params.span;
+export default function Tx({ params }: { params: { span: [string] } }) {
+  //NOTE - the params are parsed because this catch-all route merges both traceId and spanId
+  const [txId, spanId] =
+    params.span[0].length > traceIdLength
+      ? [
+          params.span[0].slice(0, traceIdLength),
+          params.span[0].slice(traceIdLength),
+        ]
+      : [params.span[0]];
 
   return (
     <Sheet defaultOpen>

--- a/app/@span/(.)[...span]/page.tsx
+++ b/app/@span/(.)[...span]/page.tsx
@@ -1,4 +1,6 @@
 import TxData from "@/components/tx-data";
+import TxSheet from "@/components/tx-data/tx-sheet";
+
 const traceIdLength = 32;
 
 export default function Tx({ params }: { params: { span: [string] } }) {
@@ -12,13 +14,11 @@ export default function Tx({ params }: { params: { span: [string] } }) {
       : [params.span[0]];
 
   return (
-    <Sheet defaultOpen>
-      <SheetContent className="min-w-[80%]">
-        <div>
-          <div>Transaction {txId}</div>
-          <TxData txId={txId} spanId={spanId} />
-        </div>
-      </SheetContent>
-    </Sheet>
+    <TxSheet>
+      <div>
+        <div>Transaction {txId}</div>
+        <TxData txId={txId} spanId={spanId} />
+      </div>
+    </TxSheet>
   );
 }

--- a/app/[...span]/page.tsx
+++ b/app/[...span]/page.tsx
@@ -1,6 +1,10 @@
 import TxData from "@/components/tx-data";
 
-export default function Tx({ params }: { params: { span: string[] } }) {
+export default function Tx({
+  params,
+}: {
+  params: { span: [string, string | undefined] };
+}) {
   const [txId, spanId] = params.span;
 
   return (

--- a/components/tx-data/index.tsx
+++ b/components/tx-data/index.tsx
@@ -2,27 +2,30 @@
 
 import { useTx } from "@/hooks/api";
 import { sequenceDiagramFromSpans } from "@/lib/mermaid";
-import Mermaid from "./mermaid";
+import { useState } from "react";
+import Mermaid from "../mermaid";
 
 type TxDataProps = {
   txId: string;
-  spanId: string;
+  spanId: string | undefined;
 };
 
 export default function TxData({ txId, spanId }: TxDataProps) {
   const { isPending, isFetching, error, data: tx } = useTx(txId);
+  const [spanIdToFind, setSpanIdToFind] = useState(spanId);
 
   if (isPending) return "Loading...";
   if (error) return "An error has occurred: " + error.message;
   if (!tx) return "Couldn't find a Tx with id: " + txId;
 
   const mermaidChart = sequenceDiagramFromSpans(tx.spans);
-
-  const span = tx.spans.find((span) => span.spanId === spanId);
+  const span = tx.spans.find((span) => span.spanId === spanIdToFind);
 
   return (
     <div>
-      {!isFetching ? <Mermaid chart={mermaidChart} /> : null}
+      {!isFetching ? (
+        <Mermaid chart={mermaidChart} setSpanId={setSpanIdToFind} />
+      ) : null}
       {span ? (
         <pre>
           {JSON.stringify(

--- a/components/tx-data/tx-sheet.tsx
+++ b/components/tx-data/tx-sheet.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { useRouter } from "next/navigation";
+import { PropsWithChildren } from "react";
+
+export default function TxSheet({ children }: PropsWithChildren) {
+  const router = useRouter();
+
+  return (
+    <Sheet
+      defaultOpen
+      onOpenChange={(open) => {
+        if (!open) {
+          router.back();
+        }
+      }}
+    >
+      <SheetContent className="min-w-[80%]">{children}</SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
Makes Tx view not reload when clicking on diagram links, while not breaking backbutton and reload functionalities, by using both React state and history.replaceState.