### PR TITLE
Support wasm msgs 

### DIFF
--- a/components/mermaid.tsx
+++ b/components/mermaid.tsx
@@ -18,6 +18,7 @@ mermaid.initialize({
     lineColor: "#fff",
     actorTextColor: "#fff",
     actorBorder: "#fff",
+    activationBkgColor: "#fff",
   },
   themeCSS: `
     .actor {

--- a/components/tx-data/index.tsx
+++ b/components/tx-data/index.tsx
@@ -2,10 +2,12 @@
 
 import { useTx } from "@/hooks/api";
 import { sequenceDiagramFromSpans } from "@/lib/mermaid";
+import { Loader2 } from "lucide-react";
 import { useState } from "react";
 import Mermaid from "../mermaid";
 import { Badge } from "../ui/badge";
 import SpanDetails from "./span-details";
+import SpansDetails from "./spans-details";
 
 type TxDataProps = {
   txId: string;
@@ -21,6 +23,7 @@ export default function TxData({ txId, spanId }: TxDataProps) {
   if (!tx) return "Couldn't find a Tx with id: " + txId;
 
   const mermaidChart = sequenceDiagramFromSpans(tx.spans);
+  const canRenderMermaid = mermaidChart !== "sequenceDiagram";
   const span = tx.spans.find((span) => span.spanId === spanIdToFind);
 
   return (
@@ -30,10 +33,18 @@ export default function TxData({ txId, spanId }: TxDataProps) {
           Transaction {txId}
         </Badge>
       </a>
-      {!isFetching ? (
-        <Mermaid chart={mermaidChart} setSpanId={setSpanIdToFind} />
-      ) : null}
-      {span ? <SpanDetails span={span} /> : null}
+      {canRenderMermaid ? (
+        <>
+          {isFetching ? (
+            <Loader2 className="animate-spin mx-auto" />
+          ) : (
+            <Mermaid chart={mermaidChart} setSpanId={setSpanIdToFind} />
+          )}
+          {span ? <SpanDetails span={span} /> : null}
+        </>
+      ) : (
+        <SpansDetails spans={tx.spans} />
+      )}
     </div>
   );
 }

--- a/components/tx-data/spans-details.tsx
+++ b/components/tx-data/spans-details.tsx
@@ -1,0 +1,20 @@
+import { Span } from "@/types/txs";
+import SpanDetails from "./span-details";
+
+type SpansDetailsProps = {
+  spans: readonly Span[];
+};
+
+export default function SpansDetails({ spans }: SpansDetailsProps) {
+  return spans.map((span) => (
+    <>
+      {spans.length > 1 ? (
+        <h2>
+          Operation <span className="font-bold">{span.operationName}</span>{" "}
+          <span className="font-mono">{span.spanId}</span>
+        </h2>
+      ) : null}
+      <SpanDetails key={span.spanId} span={span} />
+    </>
+  ));
+}

--- a/lib/mermaid.ts
+++ b/lib/mermaid.ts
@@ -76,6 +76,12 @@ export function sequenceDiagramFromSpans(spans: Readonly<Array<Span>>) {
   for (const operation of operations) {
     const { label, isQuery, sender, recipient, traceId, spanId } = operation;
     chart += `\n${sender}${isQuery ? "-" : ""}->>+${recipient}: <a href="/${traceId}/${spanId}">${label}</a>`;
+
+    if (isQuery) {
+      chart += `\nactivate ${recipient}`;
+      chart += `\n${recipient}-->>+${sender}: <a class="hidden">response placeholder</a>`;
+      chart += `\ndeactivate ${recipient}`;
+    }
   }
 
   return chart;

--- a/lib/mermaid.ts
+++ b/lib/mermaid.ts
@@ -73,8 +73,9 @@ export function sequenceDiagramFromSpans(spans: Readonly<Array<Span>>) {
     chart += `\n${getActorBox(actor)}`;
   }
 
-  for (const { label, sender, recipient, traceId, spanId } of operations) {
-    chart += `\n${sender}->>+${recipient}: <a href="/${traceId}/${spanId}">${label}</a>`;
+  for (const operation of operations) {
+    const { label, isQuery, sender, recipient, traceId, spanId } = operation;
+    chart += `\n${sender}${isQuery ? "-" : ""}->>+${recipient}: <a href="/${traceId}/${spanId}">${label}</a>`;
   }
 
   return chart;

--- a/lib/parse-ron.ts
+++ b/lib/parse-ron.ts
@@ -1,0 +1,181 @@
+import { Span } from "@/types/txs";
+
+type Operation = {
+  label: string;
+  sender: string;
+  recipient: string;
+  traceId: string;
+  spanId: string;
+};
+
+export const getActorsFromOperations = (
+  operations: readonly Operation[],
+): readonly string[] =>
+  Array.from(
+    new Set(
+      operations.flatMap((operation) => [
+        operation.sender,
+        operation.recipient,
+      ]),
+    ),
+  );
+
+export const getOperationsFromSpans = (
+  spans: Readonly<Array<Span>>,
+): readonly Operation[] =>
+  spans
+    .map((span) => {
+      const txRon =
+        span.tags.get("request") || span.tags.get("msg") || span.tags.get("tx");
+      if (!txRon) {
+        return null;
+      }
+
+      switch (true) {
+        case txRon.includes("Bank(Send"): {
+          return parseActorFromBankSendRon(txRon, span);
+        }
+        case txRon.includes("Wasm(StoreCode"): {
+          return parseActorFromWasmStoreCodeRon(txRon, span);
+        }
+        case txRon.includes("Wasm(Instantiate"): {
+          return parseActorFromWasmInstantiateRon(txRon, span);
+        }
+        case txRon.includes("Wasm(Migrate"): {
+          return parseActorFromWasmMigrateRon(txRon, span);
+        }
+        case txRon.includes("Wasm(Execute"): {
+          return parseActorFromWasmExecuteRon(txRon, span);
+        }
+        case txRon.includes("Wasm(UpdateAdmin"): {
+          return parseActorFromWasmUpdateAdminRon(txRon, span);
+        }
+        default: {
+          return null;
+        }
+      }
+    })
+    .filter((operation): operation is Operation => !!operation);
+
+const parseActorFromBankSendRon = (
+  bankSendRon: string,
+  { traceId, spanId }: Span,
+): Operation | null => {
+  const sender = bankSendRon.match(/sender: (\w+)/)?.[1];
+  const recipient = bankSendRon.match(/recipient: (\w+)/)?.[1];
+
+  if (!sender || !recipient) {
+    return null;
+  }
+
+  return {
+    label: bankSendRon.includes("Simulate(") ? "💻🏦 Send" : "🏦 Send",
+    sender,
+    recipient,
+    traceId,
+    spanId,
+  };
+};
+
+const parseActorFromWasmStoreCodeRon = (
+  wasmStoreCodeRon: string,
+  { traceId, spanId }: Span,
+): Operation | null => {
+  const sender = wasmStoreCodeRon.match(/sender: (\w+)/)?.[1];
+
+  if (!sender) {
+    return null;
+  }
+
+  return {
+    label: wasmStoreCodeRon.includes("Simulate(")
+      ? "💻🕸 Store code"
+      : "🕸 Store code",
+    sender,
+    recipient: sender,
+    traceId,
+    spanId,
+  };
+};
+
+const parseActorFromWasmInstantiateRon = (
+  wasmInstantiateRon: string,
+  { traceId, spanId }: Span,
+): Operation | null => {
+  const sender = wasmInstantiateRon.match(/sender: (\w+)/)?.[1];
+
+  if (!sender) {
+    return null;
+  }
+
+  return {
+    label: wasmInstantiateRon.includes("Simulate(")
+      ? "💻🕸 Instantiate"
+      : "🕸 Instantiate",
+    sender,
+    recipient: sender,
+    traceId,
+    spanId,
+  };
+};
+
+const parseActorFromWasmMigrateRon = (
+  wasmMigrateRon: string,
+  { traceId, spanId }: Span,
+): Operation | null => {
+  const sender = wasmMigrateRon.match(/sender: (\w+)/)?.[1];
+
+  if (!sender) {
+    return null;
+  }
+
+  return {
+    label: wasmMigrateRon.includes("Simulate(") ? "💻🕸 Migrate" : "🕸 Migrate",
+    sender,
+    recipient: sender,
+    traceId,
+    spanId,
+  };
+};
+
+const parseActorFromWasmExecuteRon = (
+  wasmExecuteRon: string,
+  { traceId, spanId }: Span,
+): Operation | null => {
+  const sender = wasmExecuteRon.match(/sender: (\w+)/)?.[1];
+  const contractAddr = wasmExecuteRon.match(/contract_addr: (\w+)/)?.[1];
+
+  if (!sender || !contractAddr) {
+    return null;
+  }
+
+  return {
+    label: wasmExecuteRon.includes("Simulate(") ? "💻🕸 Execute" : "🕸 Execute",
+    sender,
+    recipient: contractAddr,
+    traceId,
+    spanId,
+  };
+};
+
+const parseActorFromWasmUpdateAdminRon = (
+  wasmUpdateAdminRon: string,
+  { traceId, spanId }: Span,
+): Operation | null => {
+  const sender = wasmUpdateAdminRon.match(/sender: (\w+)/)?.[1];
+  const contractAddr = wasmUpdateAdminRon.match(/contract_addr: (\w+)/)?.[1];
+
+  if (!sender || !contractAddr) {
+    return null;
+  }
+
+  return {
+    label: wasmUpdateAdminRon.includes("Simulate(")
+      ? "💻🕸 Update admin"
+      : "🕸 Update admin",
+    sender,
+    recipient: contractAddr,
+    traceId,
+    spanId,
+  };
+};

--- a/lib/parse-ron.ts
+++ b/lib/parse-ron.ts
@@ -33,6 +33,11 @@ export const getOperationsFromSpans = (
       }
 
       switch (true) {
+        //NOTE - Avoids showing both execute_tx and sm.process_msg for bank queries
+        case txRon.includes("Bank(") &&
+          span.operationName === "sm.process_msg": {
+          return null;
+        }
         case txRon.includes("Bank(Send"): {
           return parseActorFromBankSendRon(txRon, span);
         }

--- a/lib/parse-ron.ts
+++ b/lib/parse-ron.ts
@@ -2,6 +2,7 @@ import { Span } from "@/types/txs";
 
 type Operation = {
   label: string;
+  isQuery: boolean;
   sender: string;
   recipient: string;
   traceId: string;
@@ -73,8 +74,11 @@ const parseActorFromBankSendRon = (
     return null;
   }
 
+  const isSimulation = bankSendRon.includes("Simulate(");
+
   return {
-    label: bankSendRon.includes("Simulate(") ? "💻🏦 Send" : "🏦 Send",
+    label: isSimulation ? "💻🏦 Send" : "🏦 Send",
+    isQuery: isSimulation,
     sender,
     recipient,
     traceId,
@@ -92,10 +96,11 @@ const parseActorFromWasmStoreCodeRon = (
     return null;
   }
 
+  const isSimulation = wasmStoreCodeRon.includes("Simulate(");
+
   return {
-    label: wasmStoreCodeRon.includes("Simulate(")
-      ? "💻🕸 Store code"
-      : "🕸 Store code",
+    label: isSimulation ? "💻🕸 Store code" : "🕸 Store code",
+    isQuery: isSimulation,
     sender,
     recipient: sender,
     traceId,
@@ -113,10 +118,11 @@ const parseActorFromWasmInstantiateRon = (
     return null;
   }
 
+  const isSimulation = wasmInstantiateRon.includes("Simulate(");
+
   return {
-    label: wasmInstantiateRon.includes("Simulate(")
-      ? "💻🕸 Instantiate"
-      : "🕸 Instantiate",
+    label: isSimulation ? "💻🕸 Instantiate" : "🕸 Instantiate",
+    isQuery: isSimulation,
     sender,
     recipient: sender,
     traceId,
@@ -134,8 +140,11 @@ const parseActorFromWasmMigrateRon = (
     return null;
   }
 
+  const isSimulation = wasmMigrateRon.includes("Simulate(");
+
   return {
-    label: wasmMigrateRon.includes("Simulate(") ? "💻🕸 Migrate" : "🕸 Migrate",
+    label: isSimulation ? "💻🕸 Migrate" : "🕸 Migrate",
+    isQuery: isSimulation,
     sender,
     recipient: sender,
     traceId,
@@ -154,8 +163,11 @@ const parseActorFromWasmExecuteRon = (
     return null;
   }
 
+  const isSimulation = wasmExecuteRon.includes("Simulate(");
+
   return {
-    label: wasmExecuteRon.includes("Simulate(") ? "💻🕸 Execute" : "🕸 Execute",
+    label: isSimulation ? "💻🕸 Execute" : "🕸 Execute",
+    isQuery: isSimulation,
     sender,
     recipient: contractAddr,
     traceId,
@@ -174,10 +186,11 @@ const parseActorFromWasmUpdateAdminRon = (
     return null;
   }
 
+  const isSimulation = wasmUpdateAdminRon.includes("Simulate(");
+
   return {
-    label: wasmUpdateAdminRon.includes("Simulate(")
-      ? "💻🕸 Update admin"
-      : "🕸 Update admin",
+    label: isSimulation ? "💻🕸 Update admin" : "🕸 Update admin",
+    isQuery: isSimulation,
     sender,
     recipient: contractAddr,
     traceId,

--- a/lib/parse-ron.ts
+++ b/lib/parse-ron.ts
@@ -35,6 +35,11 @@ export const getOperationsFromSpans = (
         case txRon.includes("Bank(Send"): {
           return parseActorFromBankSendRon(txRon, span);
         }
+        //NOTE - Avoids showing both execute_tx and sm.process_msg for wasm queries
+        case txRon.includes("Wasm(") &&
+          span.operationName === "sm.process_msg": {
+          return null;
+        }
         case txRon.includes("Wasm(StoreCode"): {
           return parseActorFromWasmStoreCodeRon(txRon, span);
         }

--- a/lib/parse-span.ts
+++ b/lib/parse-span.ts
@@ -11,7 +11,7 @@ export const getParsedSpanMap = ({ operationName, startTime, tags }: Span) => {
   const height = tags.get("height");
   height && map.set("Height", height);
 
-  const tx = tags.get("tx");
+  const tx = tags.get("request") || tags.get("msg") || tags.get("tx");
 
   const signer = tx?.match(/signer: (\w+)/)?.[1];
   signer && map.set("Signer", signer);
@@ -21,6 +21,9 @@ export const getParsedSpanMap = ({ operationName, startTime, tags }: Span) => {
 
   const recipient = tx?.match(/recipient: (\w+)/)?.[1];
   recipient && map.set("Recipient", recipient);
+
+  const contract_addr = tx?.match(/contract_addr: (\w+)/)?.[1];
+  contract_addr && map.set("Contract", contract_addr);
 
   const [, amount, denom] = tx?.match(/amount: \[Coin { (\w+) \"(\w+)/) ?? [];
   amount && denom && map.set("Amount", `${amount} ${denom}`);

--- a/tests/e2e/happy-paths.test.ts
+++ b/tests/e2e/happy-paths.test.ts
@@ -31,5 +31,5 @@ test("navigates to a correctly rendered tx detail", async ({ page }) => {
     page.getByText("layer1y6v4dtfpu5zatqgv8u7cnfwrg9cvr3chvqkv0a"),
   ).toHaveCount(1);
 
-  await expect(page.getByText("Send")).toBeVisible();
+  await expect(page.getByText("Send").first()).toBeVisible();
 });


### PR DESCRIPTION
Adds parsers for showing WASM messages (StoreCode, Instantiate, Migrate, Execute, UpdateAdmin) both on mermaid chart and on relevant info table.

Iterates through the spans of a trace, so it will show an arrow per operation.

Bank transactions (only Send supported) was already represented with a bank emoji (🏦). Now WASM transactions are represented by a spider web (🕸️) and simulations are prefixed by a computer (💻). (Not final).

<img width="1122" alt="Screenshot 2024-10-24 at 08 59 17" src="https://github.com/user-attachments/assets/296427d3-3486-42ec-9d6f-59e3cd125f4e">

<img width="1122" alt="Screenshot 2024-10-24 at 09 06 03" src="https://github.com/user-attachments/assets/ff82eaaa-6439-408b-8414-9aef6ff9c499">